### PR TITLE
#281 [Dolibarr] fix: corrige la desync produits et categories

### DIFF
--- a/modules/dolibarr/doli-products/class/class-doli-products.php
+++ b/modules/dolibarr/doli-products/class/class-doli-products.php
@@ -59,7 +59,12 @@ class Doli_Products extends Singleton_Util {
 			$wp_product->data['stock']             = (int) $doli_product->stock_reel ?? 0;
 			$wp_product->data['barcode']           = $doli_product->barcode;
 			$wp_product->data['fk_product_type']   = (int) $doli_product->type; // Product 0 or Service 1.
-			$wp_product->data['status']            = $doli_product->array_options->options__wps_status;
+
+			// Un produit sans statut WPshop explicite est considéré publié (c'est la valeur par défaut
+			// de l'extrafield "_wps_status" côté Dolibarr). Sans ce repli, un statut NULL faisait basculer
+			// le produit en brouillon et le faisait disparaître de la boutique (fausse désynchro).
+			$wps_status                            = isset( $doli_product->array_options->options__wps_status ) ? $doli_product->array_options->options__wps_status : '';
+			$wp_product->data['status']            = ( '' === $wps_status || null === $wps_status ) ? 'publish' : $wps_status;
 
 			$wp_product = Product::g()->update( $wp_product->data );
 
@@ -68,8 +73,11 @@ class Doli_Products extends Singleton_Util {
 
 				$data_sha['doli_id']     = $doli_product->id;
 				$data_sha['wp_id']       = $wp_product->data['id'];
-				$data_sha['label']       = $wp_product->data['title'];
-				$data_sha['description'] = $wp_product->data['content'];
+				// Décodage des entités HTML pour que le SHA soit insensible à l'encodage : WordPress
+				// ré-encode les caractères à l'enregistrement (&#39;->&#039;, &eacute;...), ce qui faisait
+				// systématiquement diverger ce SHA de celui recalculé côté Dolibarr (faux "désynchronisé").
+				$data_sha['label']       = html_entity_decode( (string) $wp_product->data['title'], ENT_QUOTES, 'UTF-8' );
+				$data_sha['description'] = html_entity_decode( (string) $wp_product->data['content'], ENT_QUOTES, 'UTF-8' );
 				$data_sha['price']       = $doli_product->price;
 				$data_sha['price_ttc']   = $doli_product->price_ttc;
 				$data_sha['tva_tx']      = $doli_product->tva_tx;
@@ -82,6 +90,11 @@ class Doli_Products extends Singleton_Util {
 				remove_all_actions( 'save_post' );
 				update_post_meta( $wp_product->data['id'], '_sync_sha_256', $wp_product->data['sync_sha_256'] );
 				update_post_meta( $wp_product->data['id'], '_external_id', (int) $doli_product->id );
+
+				// Écrit le lien retour (_wps_id) côté Dolibarr pour rendre la liaison bidirectionnelle.
+				// Sans cela, check_status() voyait options__wps_id vide, jugeait le produit "non lié" et
+				// supprimait _external_id : au sync suivant un nouveau produit était recréé (doublons).
+				Request_Util::get( 'doliwpshop/associateProduct?wp_id=' . (int) $wp_product->data['id'] . '&doli_id=' . (int) $doli_product->id );
 
 				// translators: Erase data for the product <strong>dolibarr</strong> data.
 				$notices['messages'][] = sprintf( __( 'Erase data for the product <strong>%s</strong> with the <strong>dolibarr</strong> data', 'wpshop' ), $wp_product->data['title'] );

--- a/modules/dolibarr/doli-sync/action/class-doli-sync-action.php
+++ b/modules/dolibarr/doli-sync/action/class-doli-sync-action.php
@@ -123,6 +123,21 @@ class Doli_Sync_Action {
 					'meta_value' => (int) $doli_entry->id,
 				), true );
 
+				// Repli anti-doublons : si le lien _external_id a été perdu, on retrouve le produit
+				// existant par sa référence (_ref) au lieu d'en recréer un nouveau à chaque synchro.
+				if ( empty( $wp_entry ) && 'wps-product' === $type && ! empty( $doli_entry->ref ) ) {
+					$wp_entry = $sync_info['wp_class']::g()->get( array(
+						'meta_key'   => '_ref',
+						'meta_value' => $doli_entry->ref,
+					), true );
+
+					// get() renvoie un tableau si plusieurs doublons partagent la même référence :
+					// on conserve alors le premier (les autres pourront être nettoyés séparément).
+					if ( is_array( $wp_entry ) ) {
+						$wp_entry = ! empty( $wp_entry ) ? reset( $wp_entry ) : null;
+					}
+				}
+
 				if ( empty( $wp_entry ) ) {
 					$wp_entry = $sync_info['wp_class']::g()->get( array( 'schema' => true ), true );
 				}

--- a/modules/dolibarr/doli-sync/class/class-doli-sync.php
+++ b/modules/dolibarr/doli-sync/class/class-doli-sync.php
@@ -185,16 +185,20 @@ class Doli_Sync extends Singleton_Util {
 
 				$messages[] = sprintf( __( 'Erase data for the product <strong>%s</strong> with the <strong>dolibarr</strong> data', 'wpshop' ), $wp_product->data['title'] );
 
-				echo do_shortcode('[wps_categories product_id="' . $wp_product->data['id'] . '"]');
-
+				// Rattachement des catégories par identifiant Dolibarr (_external_id) et non par nom :
+				// robuste aux accents/encodage et aux doublons. La catégorie absente est créée puis liée,
+				// et l'ensemble est remplacé d'un seul appel wp_set_object_terms (compteurs + caches à jour).
 				$doli_categories = Request_Util::get( 'categories/object/product/' . $entry_id . '?' );
-				$wpdb->delete($wpdb->prefix . 'term_relationships', array( 'object_id' => $wp_product->data['id'] ) );
+				$term_ids        = array();
 				if ( ! empty( $doli_categories ) ) {
 					foreach ( $doli_categories as $doli_category ) {
-						$term_taxonomy_id = get_term_by('name', $doli_category->label, 'wps-product-cat' )->term_id;
-						$wpdb->insert( $wpdb->prefix . 'term_relationships', array( 'object_id' => $wp_product->data['id'] , 'term_taxonomy_id' => $term_taxonomy_id, 'term_order' => 0 ) );
+						$term_id = $this->resolve_category_term_id( $doli_category, true );
+						if ( $term_id ) {
+							$term_ids[] = $term_id;
+						}
 					}
 				}
+				wp_set_object_terms( $wp_product->data['id'], $term_ids, 'wps-product-cat', false );
 
 				$wp_object = $wp_product;
 				break;
@@ -225,6 +229,58 @@ class Doli_Sync extends Singleton_Util {
 			'wp_error'  => $wp_error,
 			'wp_object' => $wp_object,
 		);
+	}
+
+	/**
+	 * Retrouve (ou crée) le terme WP "wps-product-cat" correspondant à une catégorie Dolibarr,
+	 * en s'appuyant sur l'identifiant Dolibarr (_external_id) plutôt que sur le nom (insensible
+	 * aux accents/encodage et aux doublons). Si le terme existe par son nom mais sans lien, on
+	 * le réutilise et on le lie (backfill de _external_id).
+	 *
+	 * @since   2.5.1
+	 *
+	 * @param  stdClass $doli_category Catégorie Dolibarr (au moins ->id et ->label).
+	 * @param  boolean  $create        Crée le terme s'il est introuvable.
+	 *
+	 * @return integer                 L'ID du terme WP, ou 0 si introuvable et non créé.
+	 */
+	private function resolve_category_term_id( $doli_category, $create = false ) {
+		if ( empty( $doli_category->id ) ) {
+			return 0;
+		}
+
+		$found = get_terms( array(
+			'taxonomy'   => 'wps-product-cat',
+			'hide_empty' => false,
+			'meta_key'   => '_external_id',
+			'meta_value' => (int) $doli_category->id,
+			'number'     => 1,
+			'fields'     => 'ids',
+		) );
+		if ( ! empty( $found ) ) {
+			return (int) $found[0];
+		}
+
+		// Repli : un terme du même nom existe déjà mais sans lien -> on le réutilise et on le lie.
+		$by_name = ! empty( $doli_category->label ) ? get_term_by( 'name', $doli_category->label, 'wps-product-cat' ) : false;
+		if ( $by_name ) {
+			update_term_meta( $by_name->term_id, '_external_id', (int) $doli_category->id );
+			return (int) $by_name->term_id;
+		}
+
+		if ( ! $create ) {
+			return 0;
+		}
+
+		$created = wp_insert_term( $doli_category->label, 'wps-product-cat', array(
+			'description' => isset( $doli_category->description ) ? $doli_category->description : '',
+		) );
+		if ( is_wp_error( $created ) || empty( $created['term_id'] ) ) {
+			return 0;
+		}
+		update_term_meta( $created['term_id'], '_external_id', (int) $doli_category->id );
+
+		return (int) $created['term_id'];
 	}
 
 	/**
@@ -261,69 +317,60 @@ class Doli_Sync extends Singleton_Util {
 
 		$response = Request_Util::get( $sync_info['endpoint'] . '/' . $external_id );
 
-		// Dolibarr return false when object is not found.
+		// Request_Util::get() renvoie false aussi bien quand l'objet est introuvable que lors d'une
+		// erreur API transitoire (timeout, 401, 500...). On ne supprime donc PLUS le lien automatiquement :
+		// une erreur passagère ne doit pas casser la liaison et provoquer des doublons au sync suivant.
 		if ( ! $response ) {
-			// @todo: Doublon
-			if ( $type == 'wps-user' ) {
-				delete_user_meta( $id, '_external_id' );
-				delete_user_meta( $id, '_sync_sha_256' );
-			} elseif ( $type == 'wps-product-cat' ) {
-				delete_term_meta( $id, '_external_id' );
-				delete_term_meta( $id, '_sync_sha_256' );
-			}  else {
-				delete_post_meta( $id, '_external_id' );
-				delete_post_meta( $id, '_sync_sha_256' );
-			}
-
 			return array(
 				'status' => true,
 				'status_code' => '0x1',
-				'status_message' => 'Dolibarr Object: #' . $external_id . ' not exist. Automatically delete external_id.',
+				'status_message' => 'Dolibarr Object: #' . $external_id . ' injoignable (lien conservé).',
 			);
 		}
 
-		// Dolibarr Object is not linked to this WP Object.
+		// Le lien retour _wps_id côté Dolibarr ne pointe pas vers ce post WP.
 		if ( $response->array_options->options__wps_id != $id ) {
-			// @todo: Doublon
-			if ( $type == 'wps-user' ) {
-				delete_user_meta( $id, '_external_id' );
-				delete_user_meta( $id, '_sync_sha_256' );
-			} elseif ( $type == 'wps-product-cat' ) {
-				delete_term_meta( $id, '_external_id' );
-				delete_term_meta( $id, '_sync_sha_256' );
+			if ( empty( $response->array_options->options__wps_id ) ) {
+				// Cas normal après un import Doli -> WP : _wps_id n'a jamais été renseigné côté Dolibarr.
+				// On RÉPARE le lien (au lieu de détruire _external_id, ce qui générait des doublons).
+				if ( $type == 'wps-product' ) {
+					Request_Util::get( 'doliwpshop/associateProduct?wp_id=' . (int) $id . '&doli_id=' . (int) $external_id );
+				} elseif ( $type == 'wps-third-party' ) {
+					Request_Util::get( 'doliwpshop/associateThirdparty?wp_id=' . (int) $id . '&doli_id=' . (int) $external_id );
+				} elseif ( $type == 'wps-product-cat' ) {
+					Request_Util::get( 'doliwpshop/associatecategory?wp_id=' . (int) $id . '&doli_id=' . (int) $external_id );
+				}
+				// Le lien est désormais cohérent : on reflète la valeur en mémoire et on poursuit la vérification.
+				$response->array_options->options__wps_id = $id;
 			} else {
-				delete_post_meta( $id, '_external_id' );
-				delete_post_meta( $id, '_sync_sha_256' );
+				// _wps_id pointe vers un AUTRE post WP : vrai conflit. On le signale sans rien supprimer.
+				return array(
+					'status' => true,
+					'status_code' => '0x2',
+					'status_message' => 'Dolibarr Object lié à un autre post WP (#' . $response->array_options->options__wps_id . '). Lien conservé.',
+				);
 			}
-
-			return array(
-				'status' => true,
-				'status_code' => '0x2',
-				'status_message' => 'Dolibarr Object is not linked to this WP Object.',
-			);
 		}
 
-		$object_id = $response->array_options->options__wps_id;
+		// Comparaison des catégories par identifiant Dolibarr (_external_id), insensible à l'ordre.
+		// (Auparavant : appariement par NOM, qui échouait dès qu'un accent/une entité différait.)
 		$doli_categories = Request_Util::get('categories/object/product/' . $response->id . '?');
-		$wp_categories   = $wpdb->get_results("SELECT * FROM ".$wpdb->term_relationships." WHERE object_id = $object_id", ARRAY_A);
 
-		$wp_category_labels = array();
 		$doli_category_labels = array();
-
-		if ( ! empty ($doli_categories) ) {
-			foreach ($doli_categories as $doli_category) {
-				$term = get_term_by('name', $doli_category->label, 'wps-product-cat' );
-				if ( ! empty($term) ) {
-					$doli_category_labels[] = get_term_by('name', $doli_category->label, 'wps-product-cat' )->term_id;
+		if ( ! empty( $doli_categories ) ) {
+			foreach ( $doli_categories as $doli_category ) {
+				$term_id = $this->resolve_category_term_id( $doli_category, false );
+				if ( $term_id ) {
+					$doli_category_labels[] = $term_id;
 				}
 			}
 		}
 
-		if ( ! empty ( $wp_categories) ) {
-			foreach ($wp_categories as $wp_category){
-				$wp_category_labels[] = $wp_category['term_taxonomy_id'];
-			}
-		}
+		$wp_category_labels = wp_get_object_terms( $id, 'wps-product-cat', array( 'fields' => 'ids' ) );
+		$wp_category_labels = is_wp_error( $wp_category_labels ) ? array() : array_map( 'intval', $wp_category_labels );
+
+		sort( $doli_category_labels );
+		sort( $wp_category_labels );
 
 		$response = apply_filters( 'doli_build_sha_' . $type, $response, $id );
 		// WP Object is not equal Dolibarr Object.
@@ -358,19 +405,23 @@ class Doli_Sync extends Singleton_Util {
 
 			$files = Request_Util::get('documents?modulepart=product&id=' . $external_id);
 
-			if (!empty($current_thumbnail_id) || !empty($files)) {
-				$file = $files[0];
+			$doli_filename = ( ! empty( $files ) && ! empty( $files[0]['filename'] ) ) ? $files[0]['filename'] : '';
+			$has_wp_image   = ! empty( $current_thumbnail_id );
+			$has_doli_image = ! empty( $doli_filename );
 
-				$existing_attachment = get_posts(array(
+			if ( $has_wp_image || $has_doli_image ) {
+				$existing_attachment = $has_doli_image ? get_posts( array(
 					'post_type'      => 'attachment',
 					'posts_per_page' => 1,
 					'post_parent'    => $id,
-					'title'          => sanitize_file_name($file['filename']),
-				));
+					'title'          => sanitize_file_name( $doli_filename ),
+				) ) : array();
 
-				if ((!empty($current_thumbnail_id) && empty($existing_attachment)) || 
-					$current_thumbnail_id != $existing_attachment[0]->ID ||
-					empty($existing_attachment) && !empty($files)) {
+				$existing_id = ! empty( $existing_attachment ) ? (int) $existing_attachment[0]->ID : 0;
+
+				// Image désynchronisée : présente d'un seul côté, ou ne correspond pas à la vignette WP.
+				if ( $has_wp_image !== $has_doli_image
+					|| ( $has_doli_image && (int) $current_thumbnail_id !== $existing_id ) ) {
 					return array(
 						'status' => true,
 						'status_code' => '0x3',

--- a/modules/dolibarr/doli-sync/filter/class-doli-sync-filter.php
+++ b/modules/dolibarr/doli-sync/filter/class-doli-sync-filter.php
@@ -93,15 +93,17 @@ class Doli_Sync_Filter extends Singleton_Util {
 		//@todo wp_id en id_wordpress
 		$data_sha['doli_id']              = $response->id;
 		$data_sha['wp_id']                = $wp_id;
-		$data_sha['label']                = $response->label;
-		$data_sha['description']          = $response->description;
+		// Même normalisation que côté écriture (Doli_Products::doli_to_wp) : on décode les entités
+		// HTML pour comparer le contenu réel et non sa représentation encodée.
+		$data_sha['label']                = html_entity_decode( (string) $response->label, ENT_QUOTES, 'UTF-8' );
+		$data_sha['description']          = html_entity_decode( (string) $response->description, ENT_QUOTES, 'UTF-8' );
 		$data_sha['price']                = $response->price;
 		$data_sha['price_ttc']            = $response->price_ttc;
 		$data_sha['tva_tx']               = $response->tva_tx;
 		$data_sha['stock']                = $response->stock_reel ?? 0;
 		$data_sha['status']               = $response->array_options->options__wps_status;
 
-		if ( $response->array_options->options__wps_status == 1  || $response->array_options->options__wps_status == 'publish' ) {
+		if ( empty( $response->array_options->options__wps_status ) || $response->array_options->options__wps_status == 1 || $response->array_options->options__wps_status == 'publish' ) {
 			$data_sha['status'] = 'publish';
 		} else {
 			$data_sha['status'] = 'draft';

--- a/modules/products/shortcode/class-products-shortcode.php
+++ b/modules/products/shortcode/class-products-shortcode.php
@@ -109,26 +109,36 @@ class Products_Shortcode {
 	 */
 	public function do_shortcode_categories( $atts ) {
 
-		global $wpdb;
+		shortcode_atts( array(
+			'product_id' => 0,
+		), $atts );
 
-		$a = shortcode_atts( [
-			'product_id' => 0,			
-		], $atts );
+		// Garantit l'existence des catégories produit de Dolibarr côté WP, de façon idempotente.
+		// IMPORTANT : l'ancienne version utilisait l'id du produit comme id de catégorie et, par une
+		// confusion de variable ($doli_category vs $doli_categories), tombait dans un else qui
+		// SUPPRIMAIT toute la taxonomie wps-product-cat à chaque synchronisation. On ne supprime plus rien.
+		$doli_categories = Request_Util::get( 'categories?type=product&sortfield=t.rowid&sortorder=ASC&limit=1000' );
 
-		if (! empty( $a['product_id'] ) ) {
-			$product_id = (int) $a['product_id'];
-			$doli_category = Request_Util::get( 'categories/' . $product_id );
-		} else {
-			$doli_categories = Request_Util::get( 'categories/'  );
-		}
+		if ( ! empty( $doli_categories ) ) {
+			foreach ( $doli_categories as $doli_category ) {
+				$existing = get_terms( array(
+					'taxonomy'   => 'wps-product-cat',
+					'hide_empty' => false,
+					'meta_key'   => '_external_id',
+					'meta_value' => (int) $doli_category->id,
+					'number'     => 1,
+					'fields'     => 'ids',
+				) );
 
-		if ( ! empty( $doli_categories )) {
-			foreach( $doli_categories as $doli_category) {
-				wp_insert_term($doli_category->label, 'wps-product-cat', array('description'=>$doli_category->description ));
+				if ( empty( $existing ) ) {
+					$term = wp_insert_term( $doli_category->label, 'wps-product-cat', array(
+						'description' => isset( $doli_category->description ) ? $doli_category->description : '',
+					) );
+					if ( ! is_wp_error( $term ) && ! empty( $term['term_id'] ) ) {
+						update_term_meta( $term['term_id'], '_external_id', (int) $doli_category->id );
+					}
+				}
 			}
-		}
-		else {
-			$wpdb->delete('wp_term_taxonomy', array('taxonomy' => 'wps-product-cat'));
 		}
 	}
 }


### PR DESCRIPTION
## Changements

### Produits
- Écriture du lien retour `_wps_id` côté Dolibarr (endpoint `doliwpshop/associateProduct`) à la synchro produit → liaison bidirectionnelle.
- `check_status()` rendu **non destructif** : ne supprime plus `_external_id` sur erreur transitoire (0x1) ou lien retour absent (0x2) ; auto-réparation du lien via `associateProduct`/`associatecategory`/`associateThirdparty`.
- **Anti-doublons** : repli d'appariement par `ref` quand `_external_id` est absent.
- **SHA normalisé** (`html_entity_decode`) des deux côtés (`doli_to_wp` + `build_sha_product`) → plus de faux « désynchronisé » sur les accents/apostrophes.
- Statut produit : un `_wps_status` vide est désormais traité comme `publish` (défaut de l'extrafield Dolibarr).
- Bloc image de `check_status()` rendu null-safe.

### Catégories
- Rattachement et comparaison des catégories **par `_external_id`** (helper `resolve_category_term_id`) au lieu du nom → robuste aux accents/encodage/doublons.
- Création de la catégorie manquante (avec `_external_id`) puis `wp_set_object_terms()` (compteurs/caches OK, plus de SQL brut).
- **Suppression du wipe de taxonomie** dans `do_shortcode_categories()` (qui effaçait toute la taxonomie `wps-product-cat` à chaque synchro) + écriture de `_external_id` sur les catégories créées.

## Fichiers modifiés
- `modules/dolibarr/doli-products/class/class-doli-products.php`
- `modules/dolibarr/doli-sync/class/class-doli-sync.php`
- `modules/dolibarr/doli-sync/action/class-doli-sync-action.php`
- `modules/dolibarr/doli-sync/filter/class-doli-sync-filter.php`
- `modules/products/shortcode/class-products-shortcode.php`

## Tests effectués (local)
- Relink des produits non liés : aucun doublon, liens `_external_id`/`_wps_id` rétablis des deux côtés.
- `check_status()` non destructif (lien conservé), 5 produits verts et stables.
- SHA : produit avec apostrophe (`&#039;` vs `&#39;`) repasse au vert.
- Catégories : taxonomie non détruite, catégorie créée + rattachée par `_external_id`, visible dans la liste de la fiche produit.

## Issue
#281

🤖 Generated with [Claude Code](https://claude.com/claude-code)
